### PR TITLE
Fix/multiple children

### DIFF
--- a/lib/rules/missing-formatted-message.js
+++ b/lib/rules/missing-formatted-message.js
@@ -43,7 +43,7 @@ module.exports = {
           // Allow for link tags to have a non-translated url
           return null;
         }
-        if (!node.children) return null;
+      if (!node.children) return null;
         let childNode = null;
         node.children.forEach((child) => {
           if (child.type === 'Literal') {
@@ -53,6 +53,7 @@ module.exports = {
               childNode = child;
             }
           }
+          if (childNode) return;
         });
         return childNode;
       }
@@ -68,7 +69,8 @@ module.exports = {
                 message: `text may need translation: "${errorNode.value}"`,
               })
             }
-            if (noWhitespace) {
+            // Only check for whitespace with single child, otherwise newlines will be flagged
+            if (noWhitespace && node.children.length === 1) {
               if (errorNode.value.startsWith(' ') || errorNode.value.endsWith(' ')) {
                 context.report({
                   node: errorNode,

--- a/lib/rules/missing-formatted-message.js
+++ b/lib/rules/missing-formatted-message.js
@@ -61,7 +61,6 @@ module.exports = {
         JSXElement: function(node) {
           const errorNode = hasChildText(node);
           if (errorNode) {
-            console.log(errorNode.value);
             // String is not just whitespace
             if (/\S/.test(errorNode.value)) {
               context.report({

--- a/lib/rules/missing-formatted-message.js
+++ b/lib/rules/missing-formatted-message.js
@@ -41,34 +41,38 @@ module.exports = {
       const hasChildText = (node) => {
         if (ignoreLinks && node.openingElement.name.name === 'a') {
           // Allow for link tags to have a non-translated url
-          return false;
+          return null;
         }
-        if (!node.children) return false;
-        if (node.children.length > 1) return false;
-        if (node.children[0] && node.children[0].type === 'Literal') {
-          if (parseInt(node.children[0].value)) {
-            return false;
+        if (!node.children) return null;
+        let childNode = null;
+        node.children.forEach((child) => {
+          if (child.type === 'Literal') {
+            if (parseInt(child.value)) {
+              childNode = null;
+            } else {
+              childNode = child;
+            }
           }
-          return true;
-        }
-        return false;
+        });
+        return childNode;
       }
 
       return {
         JSXElement: function(node) {
-          if (hasChildText(node)) {
-            const childNode = node.children[0];
+          const errorNode = hasChildText(node);
+          if (errorNode) {
+            console.log(errorNode.value);
             // String is not just whitespace
-            if (/\S/.test(childNode.value)) {
+            if (/\S/.test(errorNode.value)) {
               context.report({
-                node: childNode,
-                message: `text may need translation: "${childNode.value}"`,
+                node: errorNode,
+                message: `text may need translation: "${errorNode.value}"`,
               })
             }
             if (noWhitespace) {
-              if (childNode.value.startsWith(' ') || childNode.value.endsWith(' ')) {
+              if (errorNode.value.startsWith(' ') || errorNode.value.endsWith(' ')) {
                 context.report({
-                  node: childNode,
+                  node: errorNode,
                   message: 'no trailing whitespace',
                 })
               }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calm/eslint-plugin-react-intl",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "Linter for React-Intl integration",
   "keywords": [
     "eslint",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,16 @@
 {
   "name": "@calm/eslint-plugin-react-intl",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Linter for React-Intl integration",
   "keywords": [
     "eslint",
     "eslintplugin",
-    "eslint-plugin"
+    "eslint-plugin",
+    "react-intl",
+    "eslint-plugin-react-intl",
+    "translation",
+    "translate",
+    "i18n"
   ],
   "author": "Blaine Muri <blaine@calm.com>",
   "main": "lib/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calm/eslint-plugin-react-intl",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Linter for React-Intl integration",
   "keywords": [
     "eslint",

--- a/tests/lib/rules/missing-formatted-message.js
+++ b/tests/lib/rules/missing-formatted-message.js
@@ -41,11 +41,11 @@ ruleTester.run("missing-formatted-message", rule, {
       },
       {
         code: `<p>
-              <FormattedMessage
-                id="profile.manageSubscription.expired.message"
-                defaultMessage="You have a free Calm account. You can purchase a Calm Premium subscription to access our full library of content and features."
-              />
-            </p>`
+<FormattedMessage
+  id="profile.manageSubscription.expired.message"
+  defaultMessage="You have a free Calm account. You can purchase a Calm Premium subscription to access our full library of content and features."
+/>
+</p>`
       },
       {
         code: '<div>1</div>'
@@ -79,6 +79,15 @@ ruleTester.run("missing-formatted-message", rule, {
           errors: [
             {
               message: 'text may need translation: "hello"',
+              type: 'Literal',
+            }
+          ]
+        },
+        {
+          code: '<div><span><FormattedMessage id="test" defaultMessage="hello" /></span>Extra Text</div>',
+          errors: [
+            {
+              message: 'text may need translation: "Extra Text"',
               type: 'Literal',
             }
           ]

--- a/tests/lib/rules/missing-formatted-message.js
+++ b/tests/lib/rules/missing-formatted-message.js
@@ -41,11 +41,11 @@ ruleTester.run("missing-formatted-message", rule, {
       },
       {
         code: `<p>
-<FormattedMessage
-  id="profile.manageSubscription.expired.message"
-  defaultMessage="You have a free Calm account. You can purchase a Calm Premium subscription to access our full library of content and features."
-/>
-</p>`
+              <FormattedMessage
+                id="profile.manageSubscription.expired.message"
+                defaultMessage="You have a free Calm account. You can purchase a Calm Premium subscription to access our full library of content and features."
+              />
+            </p>`
       },
       {
         code: '<div>1</div>'
@@ -84,10 +84,15 @@ ruleTester.run("missing-formatted-message", rule, {
           ]
         },
         {
-          code: '<div><span><FormattedMessage id="test" defaultMessage="hello" /></span>Extra Text</div>',
+          code: `
+            <div>
+              <span><FormattedMessage id="test" defaultMessage="hello" /></span>
+              Extra Text
+            </div>
+          `,
           errors: [
             {
-              message: 'text may need translation: "Extra Text"',
+              message: 'text may need translation: "\n              Extra Text\n            "',
               type: 'Literal',
             }
           ]


### PR DESCRIPTION
* Fixes issue where multiple children could have text needing translation
* Only check for trailing whitespace when there is a single child (ignore newlines and jsx elements)