### PR TITLE
use child.type === 'JSXText'

### DIFF
--- a/lib/rules/missing-formatted-message.js
+++ b/lib/rules/missing-formatted-message.js
@@ -46,7 +46,7 @@ module.exports = {
         if (!node.children) return null;
         let childNode = null;
         node.children.forEach((child) => {
-          if (child.type === 'Literal') {
+          if (child.type === 'Literal' || child.type === 'JSXText') {
             if (parseInt(child.value)) {
               childNode = null;
             } else {


### PR DESCRIPTION
Not sure why, but it seems the `missing-formatted-message` wouldn't work for me until I made this change. Any ideas? Please let me know if you would like me to provide a repo where this issue can be reproduced.