### PR TITLE
[9] Feature/optional id string and default message

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,12 +35,15 @@ use case, you may want to disable this.
 
 #### Missing Attribute validation
 * <FormattedMessage/> components must have both `defaultMessage` and `id` attributes set
+  * Calm chooses to always require these, but you can optionally disable defaultMessage with option `requireDefaultMessage : false`
 * `defaultMessage` and `id` attributes cannot be empty
 * Spread operator by default is not allowed
   * Spread operator can't be evaluated by eslint's AST, so translations can't be guaranteed
 * `requireDescription` can optionally be set to require that all translations contain the description attribute
 * Use the `formatDefineMessages: true` option in order to also check the defineMessages declaration from react-intl
-  * *BE CAREFUL* - This assumes that defineMessages will always mean the react-intl method, so do not declare other defineMessages functions unless they maintain the same formatting as react-intl.
+  * *BE CAREFUL* - This assumes that defineMessages will always mean the react-intl method, so do not declare other defineMessages functions unless they maintain the same formatting as react-intl
+* Optional `requireIdAsString: false` will allow for variables in the id field
+  * *BE CAREFUL* - variables in id fields can result in duplicate strings being translated, as well as the possibility of a changed variable leading to an id without a translation associated with it
 
 ## Installation
 
@@ -93,7 +96,9 @@ The rules (with their default settings) are listed below.
                 "noTrailingWhitespace": true,
                 "noSpreadOperator": true,
                 "requireDescription": false,
-                "formatDefineMessages": false
+                "formatDefineMessages": false,
+                "requireIdAsString": true,
+                "requireDefaultMessage": true,
             }
         ],
         "@calm/react-intl/missing-values": 2

--- a/lib/rules/missing-attribute.js
+++ b/lib/rules/missing-attribute.js
@@ -33,6 +33,12 @@ module.exports = {
                   },
                   "formatDefineMessages": {
                     "type": "boolean"
+                  },
+                  "requireIdAsString": {
+                    "type": "boolean"
+                  },
+                  "requireDefaultMessage": {
+                    "type": "boolean"
                   }
               },
               "additionalProperties": false
@@ -41,10 +47,20 @@ module.exports = {
     },
 
     create: function(context) {
-      const noWhitespace = context.options[0] ? context.options[0].noTrailingWhitespace : true;
-      const noSpreadOperator = context.options[0] ? context.options[0].noSpreadOperator : true;
-      const requireDescription = context.options[0] ? context.options[0].requireDescription : false;
-      const formatDefineMessages = context.options[0] ? context.options[0].formatDefineMessages : false;
+      function getDefault(option, defaultValue) {
+        if (typeof option !== 'undefined') {
+          return Boolean(option);
+        }
+        return defaultValue;
+      }
+
+      const options = context.options[0] || {};
+      const noWhitespace = getDefault(options.noTrailingWhitespace, true);
+      const noSpreadOperator = getDefault(options.noSpreadOperator, true);
+      const requireDescription = getDefault(options.requireDescription, false);
+      const formatDefineMessages = getDefault(options.formatDefineMessages, false);
+      const requireIdAsString = getDefault(options.requireIdAsString, true);
+      const requireDefaultMessage = getDefault(options.requireDefaultMessage, true);
 
       const getAttributes = (node) => {
         if (node.type === 'JSXSpreadAttribute') {
@@ -95,9 +111,8 @@ module.exports = {
             property.value.properties.forEach((nestedProp) => {
               if (nestedProp.key && nestedProp.key.name) {
                 if (nestedProp.value) {
-                  if (nestedProp.value.type === 'Literal') {
-                    validProperties[nestedProp.key.name] = property;
-                  } else {
+                  validProperties[nestedProp.key.name] = property;
+                  if (nestedProp.value.type !== 'Literal' && requireIdAsString) {
                     return context.report({
                       node: nestedProp,
                       message: 'intl attributes must be strings',
@@ -114,10 +129,12 @@ module.exports = {
               })
             }
             if (!validProperties.defaultMessage) {
-              return context.report({
-                node: property,
-                message: 'missing attribute: defaultMessage',
-              })
+              if (requireDefaultMessage) {
+                return context.report({
+                  node: property,
+                  message: 'missing attribute: defaultMessage',
+                })
+              }
             }
             if (requireDescription && !validProperties.description) {
               return context.report({
@@ -153,10 +170,12 @@ module.exports = {
               })
             }
             if (!attributeNames.includes('defaultMessage')) {
-              context.report({
-                node: node,
-                message: 'missing attribute: defaultMessage',
-              })
+              if (requireDefaultMessage) {
+                context.report({
+                  node: node,
+                  message: 'missing attribute: defaultMessage',
+                })
+              }
             }
 
             if (requireDescription && !attributeNames.includes('description')) {
@@ -172,6 +191,9 @@ module.exports = {
                 const type = attribute.name.name;
                 if (type === 'id' || type === 'defaultMessage' || type === 'description') {
                   if (attribute.value && attribute.value.type !== 'Literal') {
+                    if (attribute.value.type === 'JSXExpressionContainer' && !requireIdAsString) {
+                      return;
+                    }
                     return context.report({
                       node: attribute.value,
                       message: "intl attributes must be strings"

--- a/lib/rules/missing-formatted-message.js
+++ b/lib/rules/missing-formatted-message.js
@@ -15,7 +15,7 @@ module.exports = {
         docs: {
             description: "Plain text between html tags requires translated intl text",
             category: "Intl",
-            recommended: false
+            recommended: true
         },
         fixable: null,  // or "code" or "whitespace"
         schema: [

--- a/tests/lib/rules/missing-attribute.js
+++ b/tests/lib/rules/missing-attribute.js
@@ -77,6 +77,39 @@ ruleTester.run("missing-attribute", rule, {
             )
           });
         `
+      },
+      {
+        code: '<FormattedMessage id={`${someVar} : button`} defaultMessage="hello world" />',
+        options: [{ requireIdAsString: false }],
+      },
+      {
+        code: `
+          import { defineMessages, FormattedMessage } from 'react-intl';
+
+          const messages = defineMessages({
+            someId: {
+              id: \`\${someVar} : button\`,
+              defaultMessage: 'world',
+            }
+          });
+        `,
+        options: [{ requireIdAsString: false, formatDefineMessages: true }],
+      },
+      {
+        code: `<FormattedMessage id="blah" />`,
+        options: [{ requireDefaultMessage: false }],
+      },
+      {
+        code: `
+          import { defineMessages, FormattedMessage } from 'react-intl';
+
+          const messages = defineMessages({
+            someId: {
+              id: 'hello',
+            }
+          });
+        `,
+        options: [{ requireDefaultMessage: false, formatDefineMessages: true }],
       }
     ],
 
@@ -201,6 +234,52 @@ ruleTester.run("missing-attribute", rule, {
           {
             message: 'missing attribute: id',
             type: 'Property'
+          }
+        ]
+      },
+      {
+        code: `
+          import { defineMessages, FormattedMessage } from 'react-intl';
+
+          const messages = defineMessages({
+            someId: {
+              id: \`\${someVar} : button\`,
+              defaultMessage: 'world',
+            }
+          });
+        `,
+        options: [{ formatDefineMessages: true }],
+        errors: [
+          {
+            message: 'intl attributes must be strings',
+            type: 'Property',
+          }
+        ]
+      },
+      {
+        code: `<FormattedMessage id="blah" />`,
+        errors: [
+          {
+            message: 'missing attribute: defaultMessage',
+            type: 'JSXOpeningElement',
+          }
+        ]
+      },
+      {
+        code: `
+          import { defineMessages, FormattedMessage } from 'react-intl';
+
+          const messages = defineMessages({
+            someId: {
+              id: 'hello',
+            }
+          });
+        `,
+        options: [{ formatDefineMessages: true }],
+        errors: [
+          {
+            message: 'missing attribute: defaultMessage',
+            type: 'Property',
           }
         ]
       }

--- a/tests/lib/rules/missing-attribute.js
+++ b/tests/lib/rules/missing-attribute.js
@@ -96,6 +96,10 @@ ruleTester.run("missing-attribute", rule, {
         options: [{ requireIdAsString: false, formatDefineMessages: true }],
       },
       {
+        code: `<FormattedMessage id={someVar} />`,
+        options: [{ requireDefaultMessage: false, requireIdAsString: false }],
+      },
+      {
         code: `<FormattedMessage id="blah" />`,
         options: [{ requireDefaultMessage: false }],
       },
@@ -110,7 +114,7 @@ ruleTester.run("missing-attribute", rule, {
           });
         `,
         options: [{ requireDefaultMessage: false, formatDefineMessages: true }],
-      }
+      },
     ],
 
     invalid: [
@@ -253,6 +257,16 @@ ruleTester.run("missing-attribute", rule, {
           {
             message: 'intl attributes must be strings',
             type: 'Property',
+          }
+        ]
+      },
+      {
+        code: `<FormattedMessage id={someVar} />`,
+        options: [{ requireDefaultMessage: false }],
+        errors: [
+          {
+            message: 'intl attributes must be strings',
+            type: 'JSXExpressionContainer',
           }
         ]
       },


### PR DESCRIPTION
# Resolves
https://github.com/calm/eslint-plugin-react-intl/issues/9

## Major Additions
- 2 new options for `missing-attribute`
  - `requireIdAsString: false` will allow for jsx expression containers for strings
 - `requireDefaultMessage: false` will allow for intl messages without a default message

## Minor Additions
- Added test cases for the two above possible missing attribute options