### PR TITLE
add textChars parameter to allow search for other non-latin alphabets

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ use case, you may want to disable this.
 * Numbers are ignored (they're the same in every language)
 * Trailing whitespace is not allowed (this can be disabled)
 * Non-alphanumeric values are ignored (such as `-`)
+* Can change what parser considers as alphabet characters. Default is `a-zA-Z`
 * Can enable enforcing label, aria-label attributes being translated (`<track label="subtitles" />`)
 * Can enable enforcing alt attributes being translated (`<img alt="description" />`)
 * Can enable enforcing inputProps being translated (`<Checkbox value="checkedA" inputProps={{ 'aria-label': 'Checkbox A' }} />`)
@@ -88,7 +89,8 @@ The rules (with their default settings) are listed below.
             "ignoreLinks": true,
             "enforceLabels": false,
             "enforceImageAlts": false,
-            "enforceInputProps": false
+            "enforceInputProps": false,
+            "textChars": "a-zA-Z"
           }
         ],
         "@calm/react-intl/missing-attribute": [2,
@@ -98,7 +100,7 @@ The rules (with their default settings) are listed below.
                 "requireDescription": false,
                 "formatDefineMessages": false,
                 "requireIdAsString": true,
-                "requireDefaultMessage": true,
+                "requireDefaultMessage": true
             }
         ],
         "@calm/react-intl/missing-values": 2

--- a/lib/rules/missing-formatted-message.js
+++ b/lib/rules/missing-formatted-message.js
@@ -36,6 +36,9 @@ module.exports = {
                   },
                   "enforceInputProps": {
                     "type": "boolean"
+                  },
+                  "textChars": {
+                    "type": "string"
                   }
               },
               "additionalProperties": false
@@ -57,6 +60,8 @@ module.exports = {
       const enforceImageAlts = getDefault(options.enforceImageAlts, false);
       const enforceLabels = getDefault(options.enforceLabels, false);
       const enforceInputProps = getDefault(options.enforceInputProps, false);
+      const textChars = typeof(options.textChars) !== 'undefined' ? options.textChars : "a-zA-Z";
+      const textCharsRegexp = new RegExp(`[${textChars}]`);
 
       function hasChildText(node) {
         if (ignoreLinks && node.openingElement.name.name === 'a') {
@@ -71,7 +76,7 @@ module.exports = {
               childNode = null;
             } else {
               // Child contains any text
-              if (child.value && /[a-zA-Z]/.test(child.value)) {
+              if (child.value && textCharsRegexp.test(child.value)) {
                 childNode = child;
               }
               // Child is whitespace only (no newlines)
@@ -130,7 +135,7 @@ module.exports = {
           const errorNode = hasChildText(node);
           if (errorNode) {
             // String is not just whitespace
-            if (/[a-zA-Z]/.test(errorNode.value)) {
+            if (textCharsRegexp.test(errorNode.value)) {
               context.report({
                 node: errorNode,
                 message: `text may need translation: "${errorNode.value}"`,

--- a/tests/lib/rules/missing-formatted-message.js
+++ b/tests/lib/rules/missing-formatted-message.js
@@ -84,6 +84,9 @@ ruleTester.run("missing-formatted-message", rule, {
       {
         code: `<Checkbox value="checkedA" inputProps={{ 'aria-label': formatMessage(messages.checkboxLabel) }} />`,
         options: [{ enforceInputProps: true, enforceImageAlts: true,  }],
+      },
+      {
+        code: "<span>Русский текст</span>",
       }
     ],
 
@@ -176,6 +179,14 @@ ruleTester.run("missing-formatted-message", rule, {
               type: 'Property',
             }
           ]
-        }
+        },
+        {
+          code: "<span>Русский текст</span>",
+          options: [{ textChars: "a-zA-Zа-яА-Я"}],
+          errors: [{
+            message: 'text may need translation: "Русский текст"',
+            type: 'Literal',
+          }]
+        },
     ]
 });


### PR DESCRIPTION
Problem: currently plugin only search for latin text. I've added a new parameter "textChars", so user can specify what characters should be considered as "alphabet".

I need it to add cyrillic characters to search. However it may be used for other alphabets.

Tests and documentation are updated too.